### PR TITLE
feat: Add 'ask' CLI command for RAG Q&A

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -6,6 +6,7 @@ os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
 import pathlib
 from shutil import copy
 import copy as copy_module
+import logging # Added for ask command
 
 import typer  # type: ignore
 import json  # Added import
@@ -21,8 +22,13 @@ from scripts.embeddings.unified_embedder import UnifiedEmbedder
 from scripts.utils.logger import LoggerManager
 from scripts.core.project_manager import ProjectManager
 from scripts.retrieval.retrieval_manager import RetrievalManager
+from scripts.prompting.prompt_builder import PromptBuilder # Added for ask command
+from scripts.api_clients.openai.completer import OpenAICompleter # Added for ask command
 
 app = typer.Typer()
+
+# Setup basic logging for the CLI
+cli_logger = LoggerManager.get_logger("cli_app")
 
 
 @app.command()
@@ -123,7 +129,7 @@ def ingest(
                 doc_type = chk.meta.get("doc_type", "default")
                 doc_type_map[doc_type].append(chk)
 
-            for doc_type, chunks in doc_type_map.items():
+            for doc_type, chunks_list in doc_type_map.items():
                 output_path = folder_path / "input" / f"chunks_{doc_type}.tsv"
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 try:
@@ -131,13 +137,13 @@ def ingest(
                         writer = csv.writer(tsvfile, delimiter="\t")
                         header = ['chunk_id', 'doc_id', 'text', 'token_count', 'meta_json']
                         writer.writerow(header)
-                        for chk in chunks:
-                            meta_json_str = json.dumps(chk.meta)
-                            writer.writerow([chk.id, chk.doc_id, chk.text, chk.token_count, meta_json_str])
-                    print(f"Wrote {len(chunks)} chunks to {output_path.name}")
+                        for chk_item in chunks_list: # Renamed variable to avoid conflict
+                            meta_json_str = json.dumps(chk_item.meta)
+                            writer.writerow([chk_item.id, chk_item.doc_id, chk_item.text, chk_item.token_count, meta_json_str])
+                    print(f"Wrote {len(chunks_list)} chunks to {output_path.name}")
                 except IOError as e:
                     error_msg = f"Error writing chunks for {doc_type}: {e}"
-                    chunker_logger(error_msg)
+                    chunker_logger.error(error_msg) # Use error level
                     raise typer.Exit(code=1)
         else:
             print("No chunks were generated.")
@@ -150,78 +156,76 @@ def embed(
     """
     Generate embeddings for chunks in the specified project directory.
     """
-    print("\n" + "=" * 120)
-    print("DEBUG: CLI embed() command STARTING")
-    print("=" * 120)
+    cli_logger.info("\n" + "=" * 120)
+    cli_logger.info("DEBUG: CLI embed() command STARTING")
+    cli_logger.info("=" * 120)
     
-    print(f"DEBUG: CLI Arguments received:")
-    print(f"DEBUG:   - project_dir: {project_dir}")
-    print(f"DEBUG:   - use_async: {use_async}")
-    print(f"DEBUG:   - use_async type: {type(use_async)}")
+    cli_logger.info(f"DEBUG: CLI Arguments received:")
+    cli_logger.info(f"DEBUG:   - project_dir: {project_dir}")
+    cli_logger.info(f"DEBUG:   - use_async: {use_async}")
+    cli_logger.info(f"DEBUG:   - use_async type: {type(use_async)}")
     
     if not project_dir.exists():
         error_msg = f"Project directory does not exist: {project_dir}"
-        print(f"ERROR: {error_msg}")
+        cli_logger.error(f"ERROR: {error_msg}")
         typer.echo(f"Error: {error_msg}")
         raise typer.Exit(1)
     
-    logger = LoggerManager.get_logger("cli")
+    # logger = LoggerManager.get_logger("cli") # Already have cli_logger
     
     # Initialize project manager
-    print("DEBUG: Creating ProjectManager...")
+    cli_logger.info("DEBUG: Creating ProjectManager...")
     project = ProjectManager(project_dir)
-    print(f"DEBUG: ProjectManager created for: {project_dir}")
+    cli_logger.info(f"DEBUG: ProjectManager created for: {project_dir}")
     runtime_config = copy_module.deepcopy(project.config)
-    print(f"DEBUG: Project config loaded: {runtime_config}")
+    cli_logger.info(f"DEBUG: Project config loaded: {runtime_config}")
 
     # Override config if async flag is provided
     if use_async:
-        print("DEBUG: CLI use_async is TRUE - Overriding config")
-        logger.info("Embedding mode override: use_async_batch=True")
+        cli_logger.info("DEBUG: CLI use_async is TRUE - Overriding config")
+        cli_logger.info("Embedding mode override: use_async_batch=True")
         
         # Set the runtime config directly (config is a plain dict)
         if 'embedding' not in runtime_config:
             runtime_config['embedding'] = {}
         
         runtime_config['embedding']['use_async_batch'] = True
-        print("DEBUG: Set runtime_config['embedding']['use_async_batch'] = True")
-        print(f"DEBUG: Updated runtime config: {runtime_config}")
-        print(f"DEBUG: Original project.config unchanged: {project.config}")
+        cli_logger.info("DEBUG: Set runtime_config['embedding']['use_async_batch'] = True")
+        cli_logger.info(f"DEBUG: Updated runtime config: {runtime_config}")
+        cli_logger.info(f"DEBUG: Original project.config unchanged: {project.config}")
         
         # Verify the setting in runtime_config (since config is a plain dict)
         if 'embedding' in runtime_config and 'use_async_batch' in runtime_config['embedding']:
             async_batch_value = runtime_config['embedding']['use_async_batch']
-            print(f"DEBUG: Verification - runtime_config['embedding']['use_async_batch'] = {async_batch_value}")
+            cli_logger.info(f"DEBUG: Verification - runtime_config['embedding']['use_async_batch'] = {async_batch_value}")
         else:
-            print("DEBUG: use_async_batch not found in runtime_config")
+            cli_logger.info("DEBUG: use_async_batch not found in runtime_config")
         
     else:
-        print("DEBUG: CLI use_async is FALSE - Using default config")
-        logger.info("Embedding mode: using default configuration")
+        cli_logger.info("DEBUG: CLI use_async is FALSE - Using default config")
+        cli_logger.info("Embedding mode: using default configuration")
     
-    print("DEBUG: About to create UnifiedEmbedder...")
+    cli_logger.info("DEBUG: About to create UnifiedEmbedder...")
     embedder = UnifiedEmbedder(project, runtime_config=runtime_config)
     
-    print(f"DEBUG: UnifiedEmbedder created:")
-    print(f"DEBUG:   - embedder.use_async_batch: {embedder.use_async_batch}")
-    print(f"DEBUG:   - Expected: {use_async}")
+    cli_logger.info(f"DEBUG: UnifiedEmbedder created:")
+    cli_logger.info(f"DEBUG:   - embedder.use_async_batch: {embedder.use_async_batch}")
+    cli_logger.info(f"DEBUG:   - Expected: {use_async}")
     
     if use_async and not embedder.use_async_batch:
-        print("ERROR: CLI flag --async was True but embedder.use_async_batch is False!")
-        print("ERROR: Configuration override failed!")
+        cli_logger.error("ERROR: CLI flag --async was True but embedder.use_async_batch is False!")
+        cli_logger.error("ERROR: Configuration override failed!")
     elif use_async and embedder.use_async_batch:
-        print("SUCCESS: CLI flag --async correctly set embedder.use_async_batch = True")
+        cli_logger.info("SUCCESS: CLI flag --async correctly set embedder.use_async_batch = True")
 
-
-
-    logger.info(f"CLI: Created embedder with use_async_batch={embedder.use_async_batch}")
+    cli_logger.info(f"CLI: Created embedder with use_async_batch={embedder.use_async_batch}")
     
-    print("DEBUG: About to call embedder.run_from_folder()...")
+    cli_logger.info("DEBUG: About to call embedder.run_from_folder()...")
     embedder.run_from_folder()
     
-    print("=" * 120)
-    print("DEBUG: CLI embed() command COMPLETE")
-    print("=" * 120)
+    cli_logger.info("=" * 120)
+    cli_logger.info("DEBUG: CLI embed() command COMPLETE")
+    cli_logger.info("=" * 120)
 
 @app.command()
 def retrieve(
@@ -233,38 +237,157 @@ def retrieve(
     """
     Retrieve top-k chunks from multiple document types using the configured strategy.
     """
+    cli_logger.info(f"Starting retrieval for project: {project_path}, query: '{query}'")
     project = ProjectManager(project_path)
     rm = RetrievalManager(project)
 
     results = rm.retrieve(query=query, top_k=top_k, strategy=strategy)
 
-    print(f"\n--- Top {len(results)} results ---")
-    for i, chunk in enumerate(results, 1):
-        print(f"\n[{i}] From {chunk.meta.get('_retriever')} | score: {chunk.meta.get('similarity', 0):.3f}")
-        print(chunk.text.strip()[:500])  # Preview max 500 chars
+    print(f"\n--- Top {len(results)} results for query: '{query}' ---")
+    if not results:
+        print("No results found.")
+    for i, chunk_item in enumerate(results, 1): # Renamed variable
+        print(f"\n[{i}] From {chunk_item.meta.get('_retriever')} | score: {chunk_item.meta.get('similarity', 0):.3f} | doc_id: {chunk_item.doc_id}")
+        source_filepath = chunk_item.meta.get('source_filepath', 'N/A')
+        print(f"    Source File: {source_filepath}")
+        page_number = chunk_item.meta.get('page_number')
+        if page_number:
+            print(f"    Page: {page_number}")
+        print(f"    Text: {chunk_item.text.strip()[:500]}...")
+    cli_logger.info(f"Retrieved {len(results)} chunks.")
+
+
+@app.command()
+def ask(
+    project_path: str = typer.Argument(..., help="Path to the RAG project directory."),
+    query: str = typer.Argument(..., help="Your question to the RAG system."),
+    top_k: int = typer.Option(5, help="Number of context chunks to retrieve."),
+    temperature: float = typer.Option(0.7, help="LLM temperature for response generation."),
+    max_tokens: int = typer.Option(500, help="LLM maximum tokens for the response."),
+    model_name: str = typer.Option("gpt-3.5-turbo", help="OpenAI model to use for generating the answer (via LiteLLM).")
+):
+    """
+    Asks a question to the RAG system.
+
+    This command retrieves relevant context chunks from the indexed documents
+    in the specified project, then uses an LLM (via LiteLLM, configured for OpenAI)
+    to generate an answer based on your query and the retrieved context.
+
+    Requires the OPENAI_API_KEY environment variable to be set for LLM access.
+    """
+    cli_logger.info(f"Starting 'ask' command for project: {project_path}")
+    cli_logger.info(f"Query: '{query}', top_k: {top_k}, model: {model_name}")
+
+    try:
+        project = ProjectManager(project_path)
+        cli_logger.info(f"ProjectManager initialized for {project.root_dir}")
+
+        # 1. Retrieve context
+        retrieval_manager = RetrievalManager(project)
+        cli_logger.info(f"RetrievalManager initialized. Retrieving top {top_k} chunks for query...")
+        retrieved_chunks = retrieval_manager.retrieve(query=query, top_k=top_k)
+
+        if not retrieved_chunks:
+            cli_logger.warning("No context chunks retrieved. Answering based on query alone might be difficult or impossible.")
+            print("\nWarning: No relevant context documents were found for your query.")
+            # Decide if to proceed or exit. For now, proceed, LMM will be told context is empty.
+        else:
+            cli_logger.info(f"Retrieved {len(retrieved_chunks)} chunks.")
+            print(f"\n--- Retrieved {len(retrieved_chunks)} context chunks ---")
+            for i, chunk_item in enumerate(retrieved_chunks, 1):
+                source_id = chunk_item.meta.get('source_filepath', chunk_item.doc_id)
+                page_info = f", page {chunk_item.meta.get('page_number')}" if chunk_item.meta.get('page_number') else ""
+                print(f"  [{i}] Source: {source_id}{page_info} (Score: {chunk_item.meta.get('similarity', 0):.3f})")
+                # print(f"      Text: {chunk_item.text[:100].strip()}...") # Optional: print chunk text preview
+
+        # 2. Build prompt
+        prompt_builder = PromptBuilder() # Uses default template
+        cli_logger.info("PromptBuilder initialized.")
+        prompt_str = prompt_builder.build_prompt(query=query, context_chunks=retrieved_chunks)
+        cli_logger.info(f"Prompt built. Length: {len(prompt_str)} chars.")
+        # cli_logger.debug(f"Generated Prompt:\n{prompt_str}") # Potentially very long
+
+        # 3. Get LMM completion
+        # API key for OpenAICompleter is handled internally (expects OPENAI_API_KEY env var)
+        try:
+            completer = OpenAICompleter(model_name=model_name)
+            cli_logger.info(f"OpenAICompleter initialized for model {model_name}.")
+        except ValueError as e:
+            cli_logger.error(f"Failed to initialize OpenAICompleter: {e}")
+            print(f"\nError: Could not initialize the LLM completer. Ensure OPENAI_API_KEY is set. Details: {e}")
+            raise typer.Exit(code=1)
+
+        print(f"\n--- Asking LLM ({model_name}) ---")
+        typer.echo("Waiting for response from LLM...")
+
+        llm_answer = completer.get_completion(
+            prompt=prompt_str,
+            temperature=temperature,
+            max_tokens=max_tokens
+            # model_name is passed to constructor, but can be overridden here if needed
+        )
+        cli_logger.info("LLM completion attempt finished.")
+
+        # 4. Print answer and sources
+        if llm_answer:
+            print("\n--- Answer ---")
+            print(llm_answer)
+            cli_logger.info(f"LLM Answer received. Length: {len(llm_answer)}")
+        else:
+            print("\n--- Answer ---")
+            print("The LLM did not provide an answer or an error occurred.")
+            cli_logger.warning("LLM did not return an answer.")
+
+        if retrieved_chunks:
+            print("\n--- Sources Used for Context ---")
+            unique_sources = set()
+            for i, chunk_item in enumerate(retrieved_chunks, 1):
+                source_id = chunk_item.meta.get('source_filepath', chunk_item.doc_id)
+                page_info = f", page {chunk_item.meta.get('page_number')}" if chunk_item.meta.get('page_number') else ""
+
+                # Create a unique identifier for the source display if needed, e.g. combining path and page
+                display_source = f"{source_id}{page_info}"
+                if display_source not in unique_sources:
+                    print(f"  - {display_source} (Retrieved as context chunk {i})")
+                    unique_sources.add(display_source)
+        else:
+            print("\nNo specific sources were retrieved to form the context for this query.")
+
+    except Exception as e:
+        cli_logger.error(f"An error occurred in the 'ask' command: {e}", exc_info=True)
+        print(f"\nAn unexpected error occurred: {e}")
+        raise typer.Exit(code=1)
+
 
 @app.command()
 def config(project_dir: Path) -> None:
     """Print config values from project directory."""
     
-    print(f"Reading config from: {project_dir}")
+    cli_logger.info(f"Reading config from: {project_dir}")
     
     # Create ProjectManager
     project = ProjectManager(project_dir)
     
     # Print basic info
+    cli_logger.info(f"Config type: {type(project.config)}")
+    cli_logger.info(f"Config value: {project.config}")
     print(f"Config type: {type(project.config)}")
     print(f"Config value: {project.config}")
     
     # If it's a dict, show the embedding section
     if isinstance(project.config, dict):
-        embedding = project.config.get('embedding', {})
-        print(f"Embedding section: {embedding}")
+        embedding_config = project.config.get('embedding', {}) # Renamed variable
+        cli_logger.info(f"Embedding section: {embedding_config}")
+        print(f"Embedding section: {embedding_config}")
         
-        if isinstance(embedding, dict):
-            use_async_batch = embedding.get('use_async_batch', 'NOT_FOUND')
+        if isinstance(embedding_config, dict):
+            use_async_batch = embedding_config.get('use_async_batch', 'NOT_FOUND')
+            cli_logger.info(f"use_async_batch: {use_async_batch} (type: {type(use_async_batch)})")
             print(f"use_async_batch: {use_async_batch} (type: {type(use_async_batch)})")
 
 
 if __name__ == "__main__":
+    # Configure root logger for CLI output if needed, or rely on LoggerManager
+    # For example, to see INFO messages from modules if not configured by LoggerManager:
+    # logging.basicConfig(level=logging.INFO)
     app()

--- a/scripts/api_clients/__init__.py
+++ b/scripts/api_clients/__init__.py
@@ -1,0 +1,1 @@
+# This file makes 'scripts/api_clients' a Python package.

--- a/scripts/api_clients/openai/__init__.py
+++ b/scripts/api_clients/openai/__init__.py
@@ -1,0 +1,5 @@
+# This file makes 'scripts/api_clients/openai' a Python package.
+from .completer import OpenAICompleter
+
+# Optionally, if you want to expose BatchEmbedder here as well
+# from .batch_embedder import BatchEmbedder

--- a/scripts/api_clients/openai/completer.py
+++ b/scripts/api_clients/openai/completer.py
@@ -1,0 +1,125 @@
+import os
+import litellm
+import logging
+
+# Initialize logger for this module
+logger = logging.getLogger(__name__)
+
+class OpenAICompleter:
+    """
+    A client for getting completions from OpenAI models via LiteLLM.
+    """
+
+    def __init__(self, api_key: str | None = None, model_name: str = "gpt-3.5-turbo"):
+        """
+        Initializes the OpenAICompleter.
+        LiteLLM will use the OPENAI_API_KEY environment variable by default if api_key is not provided.
+
+        Args:
+            api_key (str, optional): OpenAI API key. If provided, it will be used.
+                                     Otherwise, LiteLLM will look for OPENAI_API_KEY env var.
+            model_name (str, optional): Default OpenAI model to use for completions.
+                                        Defaults to "gpt-3.5-turbo".
+                                        Ensure this model name is prefixed with "openai/" if required by your LiteLLM setup,
+                                        though often not necessary for direct OpenAI calls.
+                                        For direct OpenAI, "gpt-3.5-turbo" is fine.
+        """
+        if api_key:
+            os.environ["OPENAI_API_KEY"] = api_key # LiteLLM picks this up
+
+        # Check if the API key is available for LiteLLM
+        if not os.getenv("OPENAI_API_KEY"):
+            logger.error("OpenAI API key not found. Please set the OPENAI_API_KEY environment variable or pass api_key to constructor.")
+            raise ValueError("OpenAI API key not found. Please set the OPENAI_API_KEY environment variable or pass api_key to constructor.")
+
+        # The model name for LiteLLM should be just the model ID, e.g., "gpt-3.5-turbo" for OpenAI
+        self.model_name = model_name
+        logger.info(f"OpenAICompleter initialized, will use LiteLLM for model: {self.model_name}")
+
+    def get_completion(
+        self,
+        prompt: str,
+        model_name: str | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 500,
+    ) -> str | None:
+        """
+        Gets a completion using LiteLLM.
+
+        Args:
+            prompt (str): The prompt to send to the model.
+            model_name (str, optional): The model to use. If None, uses the instance's default model.
+                                        For OpenAI, this would be e.g. "gpt-3.5-turbo", "gpt-4", etc.
+            temperature (float, optional): Sampling temperature. Defaults to 0.7.
+            max_tokens (int, optional): Maximum number of tokens to generate. Defaults to 500.
+
+        Returns:
+            str | None: The content of the completion, or None if an error occurs.
+        """
+        current_model = model_name or self.model_name
+        # For LiteLLM, ensure the model name is correctly formatted if it needs a prefix like "openai/"
+        # However, for direct OpenAI calls through LiteLLM, "gpt-3.5-turbo" is typically sufficient.
+        # If using a proxy or router, the model name might need to be "openai/gpt-3.5-turbo".
+        # For simplicity, we assume direct usage here.
+
+        logger.info(f"Requesting completion from LiteLLM for model: {current_model} with prompt (first 100 chars): '{prompt[:100]}...'")
+
+        messages = [{"role": "user", "content": prompt}]
+
+        try:
+            response = litellm.completion(
+                model=current_model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                # api_key is not explicitly passed here if OPENAI_API_KEY is set,
+                # LiteLLM handles it. If self.api_key was set in __init__ from param,
+                # it's already in os.environ.
+            )
+
+            if response.choices and response.choices[0].message and response.choices[0].message.content:
+                content = response.choices[0].message.content
+                logger.info(f"Completion received successfully via LiteLLM. Length: {len(content)} chars.")
+                return content
+            else:
+                logger.warning("No completion content received from LiteLLM or content is empty.")
+                return None
+        except litellm.exceptions.APIError as e: # Catch LiteLLM specific API errors
+            logger.error(f"LiteLLM API error: {e}")
+            return None
+        except Exception as e: # Catch any other exception
+            logger.error(f"An unexpected error occurred while getting completion via LiteLLM: {e}")
+            return None
+
+if __name__ == '__main__':
+    # Example Usage (requires OPENAI_API_KEY environment variable to be set)
+    logging.basicConfig(level=logging.INFO)
+    logger.info("Starting OpenAICompleter (via LiteLLM) direct test...")
+
+    # OPENAI_API_KEY should be set in the environment
+    if not os.getenv("OPENAI_API_KEY"):
+        logger.error("Cannot run test: OPENAI_API_KEY environment variable not set.")
+    else:
+        try:
+            # No need to pass api_key if OPENAI_API_KEY is set
+            completer = OpenAICompleter(model_name="gpt-3.5-turbo")
+            test_prompt = "What is the capital of France? Respond in one sentence."
+            logger.info(f"Sending test prompt: '{test_prompt}'")
+
+            completion_content = completer.get_completion(
+                prompt=test_prompt,
+                temperature=0.5,
+                max_tokens=50
+            )
+
+            if completion_content:
+                logger.info(f"Test completion received: {completion_content}")
+            else:
+                logger.error("Test completion failed or returned empty content.")
+
+        except ValueError as ve:
+            logger.error(f"Initialization error during test: {ve}")
+        except Exception as e:
+            logger.error(f"An unexpected error occurred during the test: {e}")
+
+    logger.info("OpenAICompleter (via LiteLLM) direct test finished.")

--- a/scripts/prompting/__init__.py
+++ b/scripts/prompting/__init__.py
@@ -1,0 +1,2 @@
+# This file makes 'scripts/prompting' a Python package.
+from .prompt_builder import PromptBuilder

--- a/scripts/prompting/prompt_builder.py
+++ b/scripts/prompting/prompt_builder.py
@@ -1,0 +1,134 @@
+import logging
+from typing import List
+from scripts.chunking.models import Chunk # Assuming Chunk model is here
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PROMPT_TEMPLATE = """
+You are a helpful AI assistant. Answer the user's query based ONLY on the provided context.
+If the context does not contain the answer, state that the answer is not found in the provided context.
+Cite the sources used to answer the query. Refer to sources using their IDs (e.g., [doc_id_1], [doc_id_2]).
+
+Context:
+{context_str}
+
+Query: {query_str}
+
+Answer:
+"""
+
+class PromptBuilder:
+    """
+    Builds prompts for the LMM by combining a user query with retrieved context chunks.
+    """
+    def __init__(self, template: str | None = None):
+        """
+        Initializes the PromptBuilder.
+
+        Args:
+            template (str, optional): A custom prompt template.
+                                      If None, DEFAULT_PROMPT_TEMPLATE is used.
+                                      Must contain {context_str} and {query_str} placeholders.
+        """
+        self.template = template or DEFAULT_PROMPT_TEMPLATE
+        if "{context_str}" not in self.template or "{query_str}" not in self.template:
+            logger.error("Prompt template must include {context_str} and {query_str} placeholders.")
+            raise ValueError("Prompt template must include {context_str} and {query_str} placeholders.")
+        logger.info("PromptBuilder initialized.")
+
+    def build_prompt(self, query: str, context_chunks: List[Chunk]) -> str:
+        """
+        Builds a complete prompt string.
+
+        Args:
+            query (str): The user's query.
+            context_chunks (List[Chunk]): A list of context chunks retrieved from the RAG system.
+
+        Returns:
+            str: The fully formatted prompt string.
+        """
+        if not context_chunks:
+            logger.warning("Building prompt with no context chunks.")
+            context_str = "No context provided."
+        else:
+            context_items = []
+            for i, chunk in enumerate(context_chunks):
+                # Prefer 'source_filepath' if available, else 'doc_id'
+                source_id = chunk.meta.get('source_filepath', chunk.doc_id)
+                # Ensure source_id is a string and usable in the prompt.
+                # Replace problematic characters if necessary, or ensure they are clean upstream.
+                source_id_str = str(source_id).replace("\n", " ").strip()
+
+                context_item = f"Source ID: [{source_id_str}]\nContent: {chunk.text}"
+
+                # Add other relevant metadata if available, e.g., page number
+                page_number = chunk.meta.get('page_number')
+                if page_number:
+                    context_item += f"\nPage: {page_number}"
+
+                context_items.append(context_item)
+            context_str = "\n\n---\n\n".join(context_items)
+
+        logger.info(f"Building prompt for query: '{query}' with {len(context_chunks)} context chunks.")
+
+        # Replace placeholders in the template
+        try:
+            final_prompt = self.template.format(context_str=context_str, query_str=query)
+        except KeyError as e:
+            logger.error(f"Missing placeholder in prompt template: {e}. Ensure template has {{context_str}} and {{query_str}}.")
+            # Fallback or re-raise, depending on desired robustness
+            raise ValueError(f"Failed to format prompt template due to missing placeholder: {e}")
+
+        logger.debug(f"Generated prompt: {final_prompt}")
+        return final_prompt
+
+if __name__ == '__main__':
+    # Example Usage
+    logging.basicConfig(level=logging.INFO)
+
+    # Mock Chunks
+    mock_chunks_data = [
+        {"doc_id": "doc1.txt", "text": "The sky is blue.", "meta": {"source_filepath": "docs/doc1.txt", "page_number": 1}, "token_count": 4},
+        {"doc_id": "doc2.pdf", "text": "An apple a day keeps the doctor away.", "meta": {"source_filepath": "pdfs/doc2.pdf"}, "token_count": 8},
+        {"doc_id": "doc3.txt", "text": "Water is essential for life.", "meta": {"source_filepath": "notes/doc3.txt", "page_number": 5}, "token_count": 6},
+    ]
+
+    context_chunks = [Chunk(**data) for data in mock_chunks_data]
+
+    user_query = "What color is the sky and why is water important?"
+
+    logger.info("Starting PromptBuilder direct test...")
+    try:
+        # Test with default template
+        builder_default = PromptBuilder()
+        prompt_default = builder_default.build_prompt(user_query, context_chunks)
+        logger.info(f"\n--- Generated Prompt (Default Template) ---\n{prompt_default}\n----------------------------------------")
+
+        # Test with a custom template
+        CUSTOM_TEMPLATE = """
+        Contextual Information:
+        ***
+        {context_str}
+        ***
+
+        Based on the information above, please answer the question: {query_str}
+        Remember to cite your sources as [Source ID string].
+        """
+        builder_custom = PromptBuilder(template=CUSTOM_TEMPLATE)
+        prompt_custom = builder_custom.build_prompt(user_query, context_chunks)
+        logger.info(f"\n--- Generated Prompt (Custom Template) ---\n{prompt_custom}\n---------------------------------------")
+
+        # Test with no context
+        prompt_no_context = builder_default.build_prompt("What is your name?", [])
+        logger.info(f"\n--- Generated Prompt (No Context) ---\n{prompt_no_context}\n------------------------------------")
+
+        # Test template validation (missing placeholder)
+        try:
+            PromptBuilder(template="Query: {query_str}") # Missing {context_str}
+        except ValueError as e:
+            logger.info(f"Successfully caught expected error for bad template: {e}")
+
+    except Exception as e:
+        logger.error(f"An error occurred during PromptBuilder test: {e}", exc_info=True)
+
+    logger.info("PromptBuilder direct test finished.")


### PR DESCRIPTION
Implemented a new 'ask' command in app/cli.py that allows users to ask questions against their indexed documents.

Key features:
- Retrieves relevant context chunks using existing RetrievalManager.
- Constructs a prompt using a new PromptBuilder, instructing the LLM to answer based on provided context and cite sources.
- Uses a new OpenAICompleter (via LiteLLM) to get completions from an OpenAI model (configurable, defaults to gpt-3.5-turbo).
- Prints the LLM's answer and a list of source documents used for context.
- Relies on OPENAI_API_KEY environment variable for API access.

New components:
- scripts/api_clients/openai/completer.py: OpenAICompleter class.
- scripts/prompting/prompt_builder.py: PromptBuilder class.

Updates:
- Added 'ask' command and necessary imports to app/cli.py.
- Improved logging consistency in app/cli.py.
- Updated docstrings for clarity.