### PR TITLE
Enable image extraction in loaders

### DIFF
--- a/scripts/ingestion/docx_loader.py
+++ b/scripts/ingestion/docx_loader.py
@@ -1,44 +1,83 @@
+from __future__ import annotations
+
 import pathlib
-import re
+from pathlib import Path
+from typing import List, Tuple
+
 from docx import Document
+from docx.oxml.ns import qn
 
-def load_docx(path: str | pathlib.Path) -> tuple[str, dict]:
-    """
-    Extracts text from a .docx file with structural markers between
-    paragraphs and tables for better downstream chunking.
 
-    Returns:
-        (text, metadata)
+def _infer_project_root(file_path: Path) -> Path:
+    """Best-effort guess of the project root from a raw file path."""
+    parts = file_path.resolve().parts
+    if "projects" in parts:
+        idx = parts.index("projects")
+        if idx + 1 < len(parts):
+            return Path(*parts[: idx + 2])
+    return file_path.parent
+
+
+def _save_image(blob: bytes, project_root: Path, filename: str) -> str:
+    rel_dir = Path("input") / "cache" / "images"
+    out_path = project_root / rel_dir / filename
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "wb") as f:
+        f.write(blob)
+    return str(rel_dir / filename)
+
+
+def load_docx(path: str | pathlib.Path) -> List[Tuple[str, dict]]:
+    """Extract text and images from a .docx file.
+
+    Returns a list of ``(text, metadata)`` tuples where ``metadata`` may contain
+    ``image_path`` if an image was found in that paragraph.
     """
-    if not isinstance(path, pathlib.Path):
-        path = pathlib.Path(path)
+    if not isinstance(path, Path):
+        path = Path(path)
 
     document = Document(path)
-    text_parts = []
+    project_root = _infer_project_root(path)
+    segments: List[Tuple[str, dict]] = []
+    file_stem = path.stem
 
-    # Process paragraphs
-    for paragraph in document.paragraphs:
-        clean_para = paragraph.text.strip()
-        if clean_para:
-            text_parts.append(clean_para)
-            text_parts.append("")  # <- for \n\n break after paragraph
+    for para_idx, paragraph in enumerate(document.paragraphs, start=1):
+        text = paragraph.text.strip()
+        if not text:
+            continue
 
-    # Process tables
-    for table in document.tables:
-        table_rows = []
+        base_meta = {"doc_type": "docx", "paragraph_number": para_idx}
+        img_count = 0
+        for run in paragraph.runs:
+            blips = run._element.xpath(".//a:blip")
+            for blip in blips:
+                rId = blip.get(qn("r:embed"))
+                image_part = document.part.related_parts.get(rId)
+                if image_part is None:
+                    continue
+                img_count += 1
+                img_name = f"{file_stem}_page{para_idx}_img{img_count}.png"
+                rel_path = _save_image(image_part.blob, project_root, img_name)
+                meta = base_meta.copy()
+                meta["image_path"] = rel_path
+                segments.append((text, meta))
+
+        if img_count == 0:
+            segments.append((text, base_meta))
+
+    # Tables are appended as additional segments
+    for tbl_idx, table in enumerate(document.tables, start=1):
+        rows = []
         for row in table.rows:
             row_cells = [cell.text.strip() for cell in row.cells if cell.text.strip()]
             if row_cells:
-                table_rows.append(" | ".join(row_cells))  # Delimit cells in row
+                rows.append(" | ".join(row_cells))
+        if rows:
+            tbl_text = "\n".join(rows)
+            meta = {
+                "doc_type": "docx",
+                "table_number": tbl_idx,
+            }
+            segments.append((tbl_text, meta))
 
-        if table_rows:
-            text_parts.append("--- TABLE START ---")  # Optional structural marker
-            text_parts.extend(table_rows)
-            text_parts.append("--- TABLE END ---")
-            text_parts.append("")  # <- extra break after table
-
-    # Join with double newlines to support paragraph-based chunking
-    full_text = "\n\n".join(text_parts)
-
-    metadata = {"source": str(path), "content_type": "docx", "doc_type": "docx"}
-    return full_text, metadata
+    return segments

--- a/scripts/ingestion/manager.py
+++ b/scripts/ingestion/manager.py
@@ -58,13 +58,27 @@ class IngestionManager:
                             # This case should ideally not be reached if LOADER_REGISTRY is set up correctly
                             print(f"Error: Loader for {item.suffix} is not callable.")
                             continue
-                        content, metadata = loader_or_class(str(item))
-                        final_meta = base_metadata.copy()
-                        final_meta.update(metadata)
-                        raw_docs.append(
-                            RawDoc(content=content, metadata=final_meta)
-                        )
-                        self.logger.debug(f"Ingested segment from {item} (function loader): {len(raw_docs)} total")
+                        result = loader_or_class(str(item))
+                        if isinstance(result, list):
+                            for text_segment, seg_meta in result:
+                                final_meta = base_metadata.copy()
+                                final_meta.update(seg_meta)
+                                raw_docs.append(
+                                    RawDoc(content=text_segment, metadata=final_meta)
+                                )
+                                self.logger.debug(
+                                    f"Ingested segment from {item} (function loader list): {len(raw_docs)} total"
+                                )
+                        else:
+                            content, metadata = result
+                            final_meta = base_metadata.copy()
+                            final_meta.update(metadata)
+                            raw_docs.append(
+                                RawDoc(content=content, metadata=final_meta)
+                            )
+                            self.logger.debug(
+                                f"Ingested segment from {item} (function loader): {len(raw_docs)} total"
+                            )
 
                 except UnsupportedFileError as e:
                     self.logger.warning(f"Loader for {item.suffix} is not callable. Found error: {e} Skipping.")

--- a/scripts/ingestion/pptx.py
+++ b/scripts/ingestion/pptx.py
@@ -1,6 +1,18 @@
+from pathlib import Path
+
 from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE_TYPE
 
 from scripts.ingestion.models import AbstractIngestor, UnsupportedFileError
+
+
+def _infer_project_root(file_path: Path) -> Path:
+    parts = file_path.resolve().parts
+    if "projects" in parts:
+        idx = parts.index("projects")
+        if idx + 1 < len(parts):
+            return Path(*parts[: idx + 2])
+    return file_path.parent
 
 
 class PptxIngestor(AbstractIngestor):
@@ -25,14 +37,39 @@ class PptxIngestor(AbstractIngestor):
         extracted_data = []
         try:
             prs = Presentation(filepath)
+            file_path = Path(filepath)
+            project_root = _infer_project_root(file_path)
+            file_stem = file_path.stem
             for i, slide in enumerate(prs.slides):
                 slide_number = i + 1
                 text_on_slide = []
 
-                # Extract text from shapes
+                image_counter = 0
+
+                # Extract text from shapes and detect images
                 for shape in slide.shapes:
                     if hasattr(shape, "text") and shape.text:
                         text_on_slide.append(shape.text.strip())
+                    if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
+                        image_counter += 1
+                        img_name = f"{file_stem}_page{slide_number}_img{image_counter}.png"
+                        rel_dir = Path("input") / "cache" / "images"
+                        out_path = project_root / rel_dir / img_name
+                        out_path.parent.mkdir(parents=True, exist_ok=True)
+                        with open(out_path, "wb") as f:
+                            f.write(shape.image.blob)
+                        img_rel = str(rel_dir / img_name)
+                        if text_on_slide:
+                            slide_content = "\n".join(text_on_slide).strip()
+                        else:
+                            slide_content = ""
+                        slide_meta = {
+                            "slide_number": slide_number,
+                            "type": "slide_content",
+                            "doc_type": "pptx",
+                            "image_path": img_rel,
+                        }
+                        extracted_data.append((slide_content, slide_meta))
 
                 # Extract text from presenter notes
                 if slide.has_notes_slide and slide.notes_slide.notes_text_frame:
@@ -50,18 +87,16 @@ class PptxIngestor(AbstractIngestor):
                         )
                         extracted_data.append((formatted_notes, notes_meta))
 
-                # Combine all text from the slide itself
+                # Combine all text from the slide itself when no images found
                 if text_on_slide:
-                    # Filter out empty strings that might result from strip()
                     valid_texts_on_slide = [t for t in text_on_slide if t]
                     if valid_texts_on_slide:
                         slide_content = "\n".join(valid_texts_on_slide).strip()
-                        # Ensure we don't add empty content after join and strip
-                        if slide_content:
+                        if slide_content and image_counter == 0:
                             slide_meta = {
                                 "slide_number": slide_number,
                                 "type": "slide_content",
-                                "doc_type": "pptx"
+                                "doc_type": "pptx",
                             }
                             extracted_data.append((slide_content, slide_meta))
 

--- a/scripts/ingestion/xlsx.py
+++ b/scripts/ingestion/xlsx.py
@@ -38,7 +38,8 @@ class XlsxIngestor(AbstractIngestor):
                             "doc_type": "xlsx",
                             "sheet_name": sheet_name,
                             "row_range": f"{chunk_start_row}-{i}",
-                            "source_filepath": filepath
+                            "source_filepath": filepath,
+                            "type": "sheet_content",
                         }
                         extracted_data.append((chunk_text, meta))
 
@@ -54,7 +55,8 @@ class XlsxIngestor(AbstractIngestor):
                         "doc_type": "xlsx",
                         "sheet_name": sheet_name,
                         "row_range": f"{chunk_start_row}-{i}",
-                        "source_filepath": filepath
+                        "source_filepath": filepath,
+                        "type": "sheet_content",
                     }
                     extracted_data.append((chunk_text, meta))
 

--- a/tests/ingestion/test_pdf_loader.py
+++ b/tests/ingestion/test_pdf_loader.py
@@ -59,17 +59,19 @@ class TestPDFLoader:
         if not SIMPLE_PDF.exists():
             pytest.skip("simple.pdf fixture not available.")
 
-        text, meta = load_pdf(SIMPLE_PDF)
+        segments = load_pdf(SIMPLE_PDF)
+
+        assert isinstance(segments, list)
+        text = "\n\n".join([seg[0] for seg in segments])
+        meta = segments[0][1]
 
         # content
         assert text == "This is page 1.\n\nThis is page 2."
 
-        # metadata
         assert meta["source_path"] == str(SIMPLE_PDF.resolve())
         assert meta["title"] == "Simple Test PDF"
         assert meta["author"] == "Test Author"
         assert meta["num_pages"] == 2
-        # created / modified may be None depending on platform
         assert "created" in meta and "modified" in meta
 
     def test_load_encrypted_pdf_raises_error(self):

--- a/tests/integration/test_project_manager.py
+++ b/tests/integration/test_project_manager.py
@@ -24,7 +24,7 @@ paths:
     assert pm.output_dir.exists()
     assert pm.logs_dir.exists()
     assert pm.get_faiss_path("pdf").name == "pdf.faiss"
-    assert "demo_project" in pm.config.get("project.name")
+    assert pm.config["project"]["name"] == "demo_project"
     print(f"Temp project created at: {tmp_path}")
 
 


### PR DESCRIPTION
## Summary
- expand ingestion manager to handle loaders returning multiple segments
- detect images in docx files and save to project cache
- extract slide images from PPTX presentations
- parse PDF images and return per-page segments
- ensure XLSX ingestor sets `type` metadata
- adjust tests for updated loaders

## Testing
- `pytest tests/ingestion/test_pdf_loader.py::TestPDFLoader::test_load_simple_pdf_success -q`
- `pytest tests/ingestion/test_pdf_loader.py::TestPDFLoader::test_load_no_text_pdf_raises_error -q`
- `pytest tests/ingestion/test_xlsx_ingestor.py::test_xlsx_ingestor_loads_sheets -q`
- `pytest tests/integration/test_project_manager.py::test_project_manager_initialization -q`
- `pytest -q` *(fails: Can't find model 'en_core_web_sm')*

------
https://chatgpt.com/codex/tasks/task_b_6873cd09dbe0832d8bf9d38e1fc006d8