### PR TITLE
Add README for utils

### DIFF
--- a/scripts/utils/README.md
+++ b/scripts/utils/README.md
@@ -1,0 +1,14 @@
+# Utility Scripts
+
+The `scripts/utils` directory provides helper modules used throughout the RAG platform. These small utilities handle common tasks such as configuration loading, logging, and file conversions.
+
+- `__init__.py` – marks the folder as a Python package.
+- `chunk_utils.py` – functions to deduplicate `Chunk` objects and load chunks from TSV files.
+- `config_loader.py` – `ConfigLoader` for reading YAML configs with dot‑notation access.
+- `create_demo_pptx.py` – generates a simple PowerPoint file used in tests.
+- `email_utils.py` – `clean_email_text` to strip quoted replies, signatures and reply blocks.
+- `image_utils.py` – utilities for saving images, caching them on disk and creating filenames.
+- `logger.py` – `LoggerManager` and `JsonLogFormatter` providing configurable console/file logging.
+- `msg2email.py` – converts Outlook `.msg` files into standard `.eml` format.
+
+These helpers support higher‑level modules like the ingestion, embedding and retrieval components.


### PR DESCRIPTION
## Summary
- document helper scripts in `scripts/utils`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scripts' because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_6876112ad684832da8f9b2cfe7f748d1